### PR TITLE
add talk & eposter materials to README

### DIFF
--- a/2020/README.md
+++ b/2020/README.md
@@ -877,7 +877,7 @@ What They Forgot to Teach You about R Workshop	|	Kara Woo, Jenny Bryan, Jim Hest
 
 **Every voice matters: An analysis of @WeAreRLadies**
 <br>by Katherine Simeon
-<br>Materials:
+<br>Materials: [slides](https://github.com/katherinesimeon/WeAreRLadies-text-data/blob/master/slides/2020-01-30-rstudioconf.pdf), [repo](https://github.com/katherinesimeon/WeAreRLadies-text-data)
 <br>🎥:
 <details><summary>Abstract</summary>
 <p><div class=""ag87-crtemvc-hsbk""><div class=css-zuif4x><p class=""carina-rte-public-DraftStyleDefault-block""><span style=""color: rgb(0,0,0);"">As a rotating curation, @WeAreRLadies is a twitter account that has a different curator (i.e., tweeter) each week with a mission to highlight female and minority genders and their work in R. So far, curators have tweeted from 18 different countries and represent a variety of domains and levels of R expertise, ranging from R novices to those developing their own packages. With 45 R-Ladies curators to date, the account has become a popular R-related twitter resource, gaining more than 13,000 followers in the past year and hundreds of interactions each week. This talk will present a text analysis and reflection on over a year of Twitter text data from @WeAreRLadies. As the founder and maintainer of this account, I witness firsthand the bidirectional relationship between one’s learning journey and their use of R. In this talk, I will attempt to quantify this through a text analysis that explores how one’s experiences learning and using R relates to how they talk (or tweet) about it. By analyzing tweet text as well as other metrics provided by twitter (e.g., number of likes, replies, and clicks), I will showcase different ways curators have engaged with the R Twitter community and explore how account engagement has changed as the number of curators and followers continue to grow. I will also discuss how curators’ different areas of expertise have resulted in tweets and discussions that both demonstrate the variety of tools available in R, and spotlight unifying ideas and best practices in R programming. Finally, I will reflect on lessons learned and future directions for @WeAreRLadies, as well as its contribution to the R-Ladies Global initiative. Overall, this talk will discuss how diverse perspectives of @WeAreRLadies curators have enriched the conversations in the R Twitter community by validating different learning journeys and by promoting and amplifying underrepresented voices.</span></p> </div></div></p></details><br>
@@ -1005,8 +1005,8 @@ What They Forgot to Teach You about R Workshop	|	Kara Woo, Jenny Bryan, Jim Hest
 
 
 **Teaching R Outside the Classroom: Supporting Instructors and Learners**
-<br>by Diya Das
-<br>Materials:
+<br>by Diya Das, Angela Li, & Katherine Simeon
+<br>Materials: [repo](https://github.com/katherinesimeon/rstudioconf2020-teachR-eposter)
 <br>
 
 


### PR DESCRIPTION
Updated README text with links to slides for my (Katherine Simeon) lightning talk as well as an EPoster, co-authored with @diyadas and @angela-li